### PR TITLE
Fixed Issue-561

### DIFF
--- a/cmd/tink-cli/cmd/hardware/get.go
+++ b/cmd/tink-cli/cmd/hardware/get.go
@@ -57,11 +57,19 @@ func (h *getHardware) PopulateTable(data []interface{}, t table.Writer) error {
 				t.AppendRow(table.Row{
 					hw.Id,
 					iface.Dhcp.Mac,
-					iface.Dhcp.Ip.Address,
+					getIpAddressValForAppendRow(iface.Dhcp.Ip),
 					iface.Dhcp.Hostname,
 				})
 			}
 		}
 	}
 	return nil
+}
+
+func getIpAddressValForAppendRow(ip *hwpb.Hardware_DHCP_IP) string {
+	var ipAddress string
+	if ip != nil {
+		ipAddress = ip.Address
+	}
+	return ipAddress
 }

--- a/cmd/tink-cli/cmd/hardware/list.go
+++ b/cmd/tink-cli/cmd/hardware/list.go
@@ -52,7 +52,7 @@ func listHardware() {
 			if quiet {
 				fmt.Println(hw.Id)
 			} else {
-				t.AppendRow(table.Row{hw.Id, iface.Dhcp.Mac, iface.Dhcp.Ip.Address, iface.Dhcp.Hostname})
+				t.AppendRow(table.Row{hw.Id, iface.Dhcp.Mac, getIpAddressValForAppendRow(iface.Dhcp.Ip), iface.Dhcp.Hostname})
 			}
 		}
 	}


### PR DESCRIPTION
## Description
This PR will fix `tink hardware get` and `tink hardware list` cmd for the partial hardware details.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #561 

## How Has This Been Tested?

1. Created partial hardware data in tink
  ```
      {
          "id": "0eba0bf8-3772-4b4a-ab9f-6ebe93b90a97",
          "network": {
            "interfaces": [
              {
                "dhcp": {
                  "mac": "52:54:00:be:a9:73"
                },
                "netboot": {
                  "allow_pxe": true
                }
              }
            ]
          }
        }
  ```
2. Built docker images for local changes and started standalone tink-server, tink-cli and postgres via tink repo's docker-compose file: `docker-compose up -d`
3. Exec-ed into tink-cli: `docker exec -it tink_tink-cli_1 sh`
4. Tested command : `tink hardware get` and `tink hardware list`
    
![Screenshot from 2022-08-22 13-10-22](https://user-images.githubusercontent.com/46951138/185916870-8d428d5f-4878-40aa-8456-90e01c64a80a.png)



## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
